### PR TITLE
Add ability to pass in a function for dependency

### DIFF
--- a/lib/check_up.ex
+++ b/lib/check_up.ex
@@ -84,6 +84,18 @@ defmodule CheckUp do
     })
   end
 
+  defp report_dependency(dep = %{status: status}) do
+    status = status.()
+
+    dep
+    |> Map.take([:id, :type])
+    |> Map.put(:attributes, %{
+      location: status.location,
+      status: status.status,
+      description: status.description
+    })
+  end
+
   defp test_db_connection(repo) do
     try do
       case Ecto.Adapters.SQL.query!(repo, "SELECT true", []) do


### PR DESCRIPTION
`op-slugs` has a dependency on elasticsearch and needs a way to check
the status of this dependency. The previous functionality only allowed
for checking Ecto.Repo's. This changeset introduces the ability to pass
in a function which should return a hash with values like the following:

```
%{
  location: "url to reach this dependency",
  status: "red or green",
  description: "a description of the error"
}
```
